### PR TITLE
Handle lock contention gracefully

### DIFF
--- a/src/code.gs
+++ b/src/code.gs
@@ -36,8 +36,8 @@ function installDailyTrigger_() {
 }
 
 function runBackupNow() {
-  withScriptLock(() => {
-    try {
+  try {
+    withScriptLock(() => {
       const folderId = getProp('BACKUP_FOLDER_ID', { required: true });
       const folder = getFolderByIdSafe_(folderId);
 
@@ -54,10 +54,10 @@ function runBackupNow() {
       const pdfFile = folder.createFile(pdfBlob);
 
       info(`バックアップ完了！\nコピー: ${copied.getUrl()}\nPDF: ${pdfFile.getUrl()}`);
-    } catch (err) {
-      fail(err, 'バックアップでエラーが発生しました：\n');
-    }
-  });
+    });
+  } catch (err) {
+    fail(err, 'バックアップでエラーが発生しました：\n');
+  }
 }
 
 function openPropertiesHelp_() {


### PR DESCRIPTION
## Summary
- ensure `runBackupNow` surfaces all failures through the shared `fail` helper so lock errors are user friendly
- convert lock acquisition failures into clear user errors when another backup is running

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d11cd8f3808325a7d1b5db8e01174c